### PR TITLE
Introduce ActionView::Component

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `RenderingHelper` supports rendering objects that `respond_to?` `:render_in`
+
+    *Joel Hawksley*, *Natasha Umer*, *Aaron Patterson*, *Shawn Allen*, *Emily Plummer*, *Diana Mounter*, *John Hawthorn*, *Nathan Herald*, *Zaid Zawaideh*, *Zach Ahn*
+
 *   Fix `select_tag` so that it doesn't change `options` when `include_blank` is present.
 
     *Younes SERRAJ*

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -35,7 +35,11 @@ module ActionView
             end
           end
         else
-          view_renderer.render_partial(self, partial: options, locals: locals, &block)
+          if options.respond_to?(:render_in)
+            options.render_in(self, &block)
+          else
+            view_renderer.render_partial(self, partial: options, locals: locals, &block)
+          end
         end
       end
 

--- a/actionview/test/lib/test_component.rb
+++ b/actionview/test/lib/test_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class TestComponent < ActionView::Base
+  include ActiveModel::Validations
+
+  validates :content, :title, presence: true
+  delegate :render, to: :view_context
+
+  def initialize(title:)
+    @title = title
+  end
+
+  # Entrypoint for rendering. Called by ActionView::RenderingHelper#render.
+  #
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context, &block)
+    self.class.compile
+    @view_context = view_context
+    @content = view_context.capture(&block) if block_given?
+    validate!
+    rendered_template
+  end
+
+  def self.template
+    <<~'erb'
+    <span title="<%= title %>"><%= content %> (<%= render(plain: "Inline render") %>)</span>
+    erb
+  end
+
+  def self.compile
+    @compiled ||= nil
+    return if @compiled
+
+    class_eval(
+      "def rendered_template; @output_buffer = ActionView::OutputBuffer.new; " +
+      ActionView::Template::Handlers::ERB.erb_implementation.new(template, trim: true).src +
+      "; end"
+    )
+
+    @compiled = true
+  end
+
+private
+
+  attr_reader :content, :title, :view_context
+end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -2,6 +2,8 @@
 
 require "abstract_unit"
 require "controller/fake_models"
+require "test_component"
+require "active_model/validations"
 
 class TestController < ActionController::Base
 end
@@ -669,6 +671,21 @@ module RenderTestCases
 
   def test_render_throws_exception_when_no_extensions_passed_to_register_template_handler_function_call
     assert_raises(ArgumentError) { ActionView::Template.register_template_handler CustomHandler }
+  end
+
+  def test_render_component
+    assert_equal(
+      %(<span title="my title">Hello, World! (Inline render)</span>),
+      @view.render(TestComponent.new(title: "my title")) { "Hello, World!" }.strip
+    )
+  end
+
+  def test_render_component_with_validation_error
+    error = assert_raises(ActiveModel::ValidationError) do
+      @view.render(TestComponent.new(title: "my title")).strip
+    end
+
+    assert_match "Content can't be blank", error.message
   end
 end
 


### PR DESCRIPTION
_This is a test/draft version of the PR we plan to open on Rails next week._

# Introduce ActionView::Component

`ActionView::Component` provides a framework for building view components.

We’ve been running a variant of this patch in production at GitHub since March, and now have about a dozen components used in over a hundred call sites.

[I spoke about `ActionView::Component` at RailsConf](https://www.youtube.com/watch?v=y5Z5a6QdA-M), where we got lots of great feedback from the community. Several folks asked us to upstream it into Rails.

## Why

In working on views in our Rails monolith at GitHub (which has over 3700 templates), we have run into several key pain points:

### Testing

Currently, Rails encourages testing views via integration or system tests. This disincentivizes us from testing our views thoroughly, due to the costly overhead of exercising the routing/controller layer, instead of just the view. It also often leads to partials being tested for each view they are included in, cheapening the benefit of DRYing up our views.

### Code Coverage

Many common Ruby code coverage tools cannot properly handle coverage of views, making it difficult to audit how thorough our tests are and leading to gaps in our test suite.

### Data Flow

Unlike a method declaration on an object, views do not declare the values they are expected to receive, making it hard to figure out what context is necessary to render them. This often leads to subtle bugs when we reuse a view across different contexts.

### Standards

Our views often fail even the most basic standards of code quality we expect out of our Ruby classes: long methods, deep conditional nesting, and mystery guests abound.

## ActionView::Component

`ActionView::Component` is an effort to address these pain points in a way that improves the Rails view layer.

### Building Components

Components are subclasses of `ActionView::Component` and live in `app/components`.

Components implement a `.template` class method with a HEREDOC containing ERB, and an optional initializer. All other methods should be private.

Components support ActiveModel validations. Components are validated after initialization, but before rendering.

### Example

Given the component `app/components/test_component.rb`: 

```ruby
class TestComponent < ActionView::Component
  validates :content, :title, presence: true

  def initialize(title:)
    @title = title
  end

  def self.template
    <<~'erb'
    <span title="<%= title %>"><%= content %></span>
    erb
  end

  private

  attr_reader :title
end
```

We can render it in a view as:

```erb
<%= render(TestComponent, title: "my title" ) do %>
  Hello, World!
<% end %>
```

Which returns:

```html
<span title="my title">Hello, World!</span>
```

### Error case

If the component is rendered with a blank title:

```erb
<%= render(TestComponent, title: "") do %>
  Hello, World!
<% end %>
```

An error will be raised:

`ActiveModel::ValidationError: Validation failed: Title can't be blank`

## Testing

Components are unit tested directly. The `render_component` test helper renders a component and wraps the result in `Nokogiri.HTML`, allowing us to test the component above as:

```ruby
def test_render_component
  assert_equal(
    %(<span title="my title">Hello, World!</span>),
    render_component(TestComponent, title: "my title" ) { "Hello, World!" }.css("span").to_html
  )
end
```

In general, we’ve found it makes the most sense to test components based on their rendered HTML, as their only public instance method is `html`.

## Benefits

### Testing

`ActionView::Component` allows views to be unit-tested. Our unit tests run in around 25ms/test, vs. ~6s/test for integration tests.

### Code Coverage

`ActionView::Component` is at least partially compatible with code coverage tools. We’ve seen some success with SimpleCov.

### Data flow

By clearly defining the context necessary to render a component, we’ve found them to be easier to reuse than partials.

### Performance

In early benchmarks, we’ve seen performance improvements over the existing rendering pipeline. For a test page with nested renders 10 levels deep, we’re seeing around a 5x increase in speed over partials: 

```
Comparison:
           component:     6515.4 i/s
             partial:     1251.2 i/s - 5.21x  slower
```

_Rails 6.1.0.alpha, [joelhawksley/actionview-component-demo](https://github.com/joelhawksley/actionview-component-demo), /benchmark route, via `RAILS_ENV=production rails s`, measured with [evanphx/benchmark-ips](https://github.com/evanphx/benchmark-ips)_

## Open Questions

### API

We’ve been pretty happy with what we have so far. 

@cgriego and others have [suggested that we consider using a hash key](https://github.com/joelhawksley/actionview-component-demo/issues/6) (like `render(component: TestComponent)`), but in practice this has felt overly verbose, especially in cases where we might be rendering combinations of dozens of components.

@zachahn and others have [suggested we pass an instantiated component to #render](https://github.com/joelhawksley/rails/pull/1#issuecomment-497705278) which feels a little more Ruby-like, but a little less Railsy to me. 

### Rails integration

We’re not sure if the current integration point in Rails (`ActionView::RenderingHelper#render`) is the best option. 

### Naming

Traditionally, Rails views have been named according to the controller actions that render them. With `ActionView::Component`, things aren’t so simple.

We’ve seen good results mimicking the levels of abstraction[ Dan Abramov calls Presentational and Container Components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0). Presentational components worry about how things _look_, and Container components worry about how things _work_.

For Presentational components, we’ve been naming them according to the UI element they represent (`Tag`, `Badge`, etc).

For Container components, we’ve been namespacing them within the domain concept they represent (`Languages`, `Topics`, `PullRequests`) and naming them according to the Presentational component they build (`Tag`, `Badge`, etc).

### Template architecture

Having the ERB template inside a Ruby file doesn’t feel quite right. 

Not all editors like highlighting HEREDOCs. Perhaps we could allow a sidecar template file instead? (i.e. `component.html.erb` sitting alongside `component.rb`)

[@skyksandr mentioned that Sinatra does inline templates at the bottom of the file](https://github.com/joelhawksley/actionview-component-demo/issues/4).

Currently, we use HEREDOCs with string interpolation disabled. This doesn’t feel super user-friendly, and weird errors arise in certain situations if string interpolation is enabled.

### Templating engine support

We should probably support arbitrary templating engines like normal Rails views. 

### Use of ActiveModel::Validations

As @dhh pointed out when we discussed this at RailsConf, we’re using `ActiveModel::Validations` in a non-user-facing manner, something not traditionally done.

### Component previews

@xdmx and others have suggested we consider something akin to `ActionMailer::Preview` to render components individually.

### (Not) Calling `super` in `initialize`

We are not calling `super` in our component's `initialize` methods as the current `ActionView::Base` initializer is built for view files. This awkward inheritance is a symptom of `ActionView::Component` being a subset of the functionality in `ActionView::Base`. @tenderlove believes we should eventually flip the inheritance structure so that `ActionView::Base` contains only what is need for _both_ regular views and components.

### Support for other Rails niceties 

We’d probably want to support url helpers, generators, locales, request formats, and other existing Rails view layer features. Right now helpers must be explicitly included before they can be used in a component.

## Existing implementations

`ActionView::Component` is far from a novel idea. Popular implementations of view components in Ruby include, but are not limited to:

- [trailblazer/cells](https://github.com/trailblazer/cells)
- [dry-rb/dry-view](https://github.com/dry-rb/dry-view)
- [komposable/komponent](https://github.com/komposable/komponent)
- [activeadmin/arbre](https://github.com/activeadmin/arbre)

## In action

I’ve created a [demo repository](https://github.com/joelhawksley/actionview-component-demo) pointing to this branch.

## Co-authored-by

A cross-functional working group of engineers and members of our Design Systems team collaborated on this work, including by not limited to: @natashau, @tenderlove, @shawnbot, @emplums, @broccolini, @jhawthorn, @myobie, and @zawaideh.

Additionally, numerous members of the community have shared their ideas for `ActionView::Component`, including but not limited to: @cgriego, @xdmx, @skyksandr, @jcoyne, @dylanahsmith, @kennyadsl, @cquinones100, @erikaxel, @zachahn, and @trcarden.